### PR TITLE
Use AWS credential chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ This fork uses standard `s3://` scheme unlike the original (which uses `s3c://`)
 
 ### Credentials
 
-* Environment
+* AWS
 
-```sh
-AWS_ACCESS_KEY_ID="myKey"
-AWS_SECRET_ACCESS_KEY="myVeryS3cret"
-AWS_DEFAULT_REGION="eu-east-1"
-```
+If you have an AWS profile called "artifacts", credentials will be read from there. Otherwise they will
+be read from the [default](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html)
+AWS chain.
+
+Region will be read from the [default](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/regions/providers/DefaultAwsRegionProviderChain.html)
+AWS chain.
 
 * File
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ region = eu-east-1
 
 ### Usage
 
+You'll need any version of `coursier`, which can then bootstrap and produce a new coursier jar.
+
 ```shell
 $ coursier bootstrap coursier:1.1.0-M14 rtfpessoa:coursier-s3_2.12:0.2.0-SNAPSHOT --assembly -o coursier-1.1.0-M14-s3.sh
 $ tail -c +458 coursier-1.1.0-M14-s3.sh > coursier-1.1.0-M14-s3.jar

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ organization := "rtfpessoa"
 
 name := """coursier-s3"""
 
-version := "0.2.0-SNAPSHOT"
+version := "0.3.0-SNAPSHOT"
 
 scalaVersion := "2.12.8"
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ organization := "rtfpessoa"
 
 name := """coursier-s3"""
 
-version := "0.4.0-SNAPSHOT"
+version := "0.6.0-SNAPSHOT"
 
 scalaVersion := "2.12.8"
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ organization := "rtfpessoa"
 
 name := """coursier-s3"""
 
-version := "0.3.0-SNAPSHOT"
+version := "0.4.0-SNAPSHOT"
 
 scalaVersion := "2.12.8"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.4.4

--- a/src/main/scala/coursier/cache/protocol/S3Handler.scala
+++ b/src/main/scala/coursier/cache/protocol/S3Handler.scala
@@ -7,12 +7,15 @@ import java.nio.file.{Path, Paths}
 
 import awscala.Credentials
 import awscala.s3.{Bucket, S3, S3Object}
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
+import com.amazonaws.regions.DefaultAwsRegionProviderChain
 import com.amazonaws.services.s3.model.GetObjectRequest
 
 import scala.collection.breakOut
 import scala.io.{Codec, Source}
-import scala.util.control.NonFatal
 import scala.util.{Properties, Try}
+import scala.util.control.NonFatal
 
 /*
  * Our handler only supports one kind of URL:
@@ -21,8 +24,15 @@ import scala.util.{Properties, Try}
  * For now the region in the url is being ignored.
  *
  * It does not support credentials in the URLs for security reasons.
- * You should provide them as environment variables or
- * in `.s3credentials` in $HOME, $HOME/.sbt, $HOME/.coursier
+ *
+ * You should provide credentials in one of the following places:
+ * 1. In a "artifacts" AWS profile
+ * 2. Anywhere in the default AWS chain: https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html
+ * 3. In a`.s3credentials` file at $HOME, $HOME/.sbt, $HOME/.coursier
+ *
+ * You should provide region in one of the following places:
+ * 1. Anywhere in the default AWS chain: https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/regions/providers/DefaultAwsRegionProviderChain.html
+ * 2. In a`.s3credentials` file at $HOME, $HOME/.sbt, $HOME/.coursier
  */
 class S3HandlerNotFactory extends URLStreamHandler {
 
@@ -58,25 +68,33 @@ class S3HandlerNotFactory extends URLStreamHandler {
   }
 
   private def getClient: Option[S3] = {
-    readFromEnv
+    readFromArtifactsProfile
+      .orElse(readfromAwsChain)
       .orElse(readFromFile(Paths.get("").toAbsolutePath))
       .orElse(readFromFile(Paths.get(Properties.userHome)))
       .orElse(readFromFile(Paths.get(Properties.userHome).resolve(".sbt")))
       .orElse(readFromFile(Paths.get(Properties.userHome).resolve(".coursier")))
   }
 
-  private def readFromEnv: Option[S3] = {
-    for {
-      accessKey <- sys.env.get("AWS_ACCESS_KEY_ID")
-      secretKey <- sys.env.get("AWS_SECRET_ACCESS_KEY")
-    } yield {
-      val region = sys.env.get("AWS_DEFAULT_REGION")
-        .map(awscala.Region.apply)
-        .getOrElse(awscala.Region.EU_WEST_1)
+  private def readFromArtifactsProfile: Option[S3] = Try {
+    val regionProv = new DefaultAwsRegionProviderChain()
+    val credProv = new ProfileCredentialsProvider("artifacts")
 
-      S3(Credentials(accessKey, secretKey))(region)
-    }
-  }
+    S3(Credentials(
+      credProv.getCredentials.getAWSAccessKeyId,
+      credProv.getCredentials.getAWSSecretKey
+    ))(awscala.Region(regionProv.getRegion))
+  }.toOption
+
+  private def readfromAwsChain: Option[S3] = Try {
+    val regionProv = new DefaultAwsRegionProviderChain()
+    val credProv = new DefaultAWSCredentialsProviderChain()
+
+    S3(Credentials(
+      credProv.getCredentials.getAWSAccessKeyId,
+      credProv.getCredentials.getAWSSecretKey
+    ))(awscala.Region(regionProv.getRegion))
+  }.toOption
 
   private def readFromFile(path: Path): Option[S3] = {
     val file = path.resolve(".s3credentials").toFile

--- a/src/main/scala/coursier/cache/protocol/S3Handler.scala
+++ b/src/main/scala/coursier/cache/protocol/S3Handler.scala
@@ -76,7 +76,7 @@ class S3HandlerNotFactory extends URLStreamHandler {
       .orElse(readFromFile(Paths.get(Properties.userHome).resolve(".coursier")))
   }
 
-  private def readFromArtifactsProfile: Option[S3] = Try {
+  private lazy val readFromArtifactsProfile: Option[S3] = Try {
     val regionProv = new DefaultAwsRegionProviderChain()
     val credProv = new ProfileCredentialsProvider("artifacts")
 
@@ -86,7 +86,7 @@ class S3HandlerNotFactory extends URLStreamHandler {
     ))(awscala.Region(regionProv.getRegion))
   }.toOption
 
-  private def readfromAwsChain: Option[S3] = Try {
+  private lazy val readfromAwsChain: Option[S3] = Try {
     val regionProv = new DefaultAwsRegionProviderChain()
     val credProv = new DefaultAWSCredentialsProviderChain()
 


### PR DESCRIPTION
Try using `ProfileCredentialsProvider("artifacts")`, then fallback to `DefaultAWSCredentialsProviderChain `.

Removed the code that reads from the environment variables directly, `DefaultAWSCredentialsProviderChain` does that already. See the link below for the places it looks.

### Test Plan
Try it live

### Deploy
```
sbt publishLocal
// download a coursier jar from anywhere like https://mvnrepository.com/artifact/io.get-coursier/coursier_2.13/2.0.0-RC6-9
// NOTE: only <=RC6-9 works with pants1.27!!!
java -jar ~/Downloads/coursier.jar bootstrap coursier:2.0.0-RC6-9 rtfpessoa:coursier-s3_2.12:<thisVersion>-SNAPSHOT --assembly -o coursier-2.0.0-RC6-9-s3-<thisVersion>-aiq.sh
tail -c +458 ./coursier-2.0.0-RC6-9-s3-<thisVersion>-aiq.sh > coursier-2.0.0-RC6-9-s3-<thisVersion>-aiq.jar
aws s3 cp coursier-2.0.0-RC6-9-s3-<thisVersion>-aiq.jar s3://aiq-public/pants/build-support/bin/coursier/2.0.0-RC6-9-s3-<thisVersion>/coursier-2.0.0-RC6-9-s3-<thisVersion>.jar
```
